### PR TITLE
Clip only long NFT names

### DIFF
--- a/src/pages/dashboard/TokenActivityItem.css
+++ b/src/pages/dashboard/TokenActivityItem.css
@@ -90,10 +90,6 @@
     line-height: 1.3;
     /* font-size: 1.25rem; */
     margin-right: 5px;
-    max-width: 150px;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .send-activity .activity-item__amount {
@@ -105,6 +101,13 @@
 
 .activity-item--nft {
     position: relative;
+}
+
+.activity-item--nft .activity-item__amount {
+    max-width: 150px;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .activity-item--nft .activity-item_type-icon-w {


### PR DESCRIPTION
Fix issue that clipped displayed amount in Activity, so that it clippes only long NFT names.